### PR TITLE
Added subtitle to pages

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -27,6 +27,8 @@ if (page.archive){
   }
 } else if (is_home()) {
   title = '<em class="page-title-link" data-url="home">' + __('index.home') + '</em>';
+} else if (page.subtitle) {
+  title = '<em class="page-title-link" data-url="' + url_for(page.path) + '">' + page.subtitle + '</em>';
 } else if (page.title) {
   title = '<em class="page-title-link" data-url="' + url_for(page.path) + '">' + page.title + '</em>';
 } else {


### PR DESCRIPTION
Added subtitle support to markdown pages. The subtitle displays where the category would normally show. Usage:

title: My Page Title
subtitle: My Subtitle For This Page
comments: false
