### PR TITLE
Added support for explicit disqus identifier in post comments.

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -1,6 +1,9 @@
 <% if (config.disqus_shortname){ %>
 <script>
   var disqus_shortname = '<%= config.disqus_shortname %>';
+  <% if (config.useDisqusId){ %>
+  var disqus_identifier = '<%= page.disqusId || page.slug %>';
+  <% } %>
   <% if (page.permalink){ %>
   var disqus_url = '<%= page.permalink %>';
   <% } %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -47,9 +47,6 @@
   <% if (post.comments && config.disqus_shortname){ %>
     <section id="comments">
       <div id="disqus_thread">
-        <% if (config.useDisqusId){ %>
-          <script>var disqus_identifier = '<%= post.disqusId || post.slug %>';</script>
-        <% } %>
         <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
       </div>
     </section>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -47,6 +47,9 @@
   <% if (post.comments && config.disqus_shortname){ %>
     <section id="comments">
       <div id="disqus_thread">
+        <% if (config.useDisqusId){ %>
+          <script>var disqus_identifier = '<%= post.disqusId || post.slug %>';</script>
+        <% } %>
         <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
       </div>
     </section>


### PR DESCRIPTION
To use, modify _config.yml and include the optional parameter:

useDisqusId: true

If true, posts will include a disqus_identifier in their content, using post.slug by default. You can specify an explicit disqus_identifier value by including the variable disqusId in a post's markdown file. For example:

disqusId: 162