### PR TITLE
Bug fix for showing multiple Pages or Categories in the header.

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -20,7 +20,7 @@
                   if(i == 'Categories'){ %>
                     <%- list_categories({show_count: false, depth: 2, class: 'main-nav', style: 'list'}) %>
                   <% } else { %>
-                <li class="main-nav-list-item" ><a class="main-nav-list-link" href="<%- url_for(theme.menu[i]) %>"><%= __('index.' + i.toLowerCase()) %></a></li>
+                <li class="main-nav-list-item" ><a class="main-nav-list-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a></li>
               <% }} %>
             </ul>
             <nav id="sub-nav">


### PR DESCRIPTION
This is a bug fix for showing multiple pages or categories in the header. Previously, it would show "index.pageName" instead of just "pageName" in the header. This applies to pages and categories that are added via _config.yml. Here is an example of the bug:

```
# Header
menu:
  Home: /
  About: /about
  Contact: /contact
  404: /404
  Categories:
  One: /about
  Two: /contact
```

Bug screenshot:
![hueman_header_page_names](https://cloud.githubusercontent.com/assets/529049/11158506/99b50546-8a26-11e5-96b2-ec09645b3152.png)

Fix applied:
![hueman_header_page_names_fix](https://cloud.githubusercontent.com/assets/529049/11158568/1d68d4da-8a27-11e5-8480-fa8580fe62d9.jpg)
