### PR TITLE
Fix menu titles being garbled

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -20,7 +20,7 @@
                   if(i == 'Categories'){ %>
                     <%- list_categories({show_count: false, depth: 2, class: 'main-nav', style: 'list'}) %>
                   <% } else { %>
-                <li class="main-nav-list-item" ><a class="main-nav-list-link" href="<%- url_for(theme.menu[i]) %>"><%= __('index.' + i.toLowerCase()) %></a></li>
+                <li class="main-nav-list-item" ><a class="main-nav-list-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a></li>
               <% }} %>
             </ul>
             <nav id="sub-nav">


### PR DESCRIPTION
I couldn't work out what the logic in the template on the inside of the <a> tag was for, but it meant that extra menu titles were being lower cased and perpended with "index." which didn't seem right for the text of a link.