### PR TITLE
Fix fancybox image source

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -20,7 +20,7 @@
                 $(this).after('<span class="caption">' + alt + '</span>');
             }
 
-            $(this).wrap('<a href="' + this.src + '" title="' + alt + '" class="fancybox"></a>');
+            $(this).wrap('<a href="' + this.getAttribute('data-url') + '" title="' + alt + '" class="fancybox"></a>');
         });
 
         $(this).find('.fancybox').each(function(){


### PR DESCRIPTION
When executing this script, the "this.src" is empty so the consequence is that the users can't open the images within fancybox. The original source content is in the "data-url" attribute. It's working on my blog now, please confirm it's also working for you.