### PR TITLE
Fixed bug with showing Disqus comment count for pages that use a Disq…

### DIFF
--- a/layout/comment/counter.ejs
+++ b/layout/comment/counter.ejs
@@ -2,7 +2,7 @@
 <span class="comment-counter">
     <i class="fa fa-comments-o"></i>
     <% if (theme.comment.disqus) { %>
-        <span class="disqus-comment-count" data-disqus-url="<%= post.permalink %>">0</span>
+        <span class="disqus-comment-count" data-disqus-identifier="<%= post.disqusId || '' %>" data-disqus-url="<%= post.permalink %>">0</span>
     <% } else if (theme.comment.duoshuo) { %>
         <span class="ds-thread-count" data-thread-key="<%= post.path %>">0</span>
     <% } %>


### PR DESCRIPTION
This fixes broken Disqus comment counts that were not displaying for posts that use a DisqusId identifier instead of the url.

Note inclusion of the new tag `data-disqus-identifier`

```html
<span class="disqus-comment-count" data-disqus-identifier="12345" data-disqus-url="http://yoursite.com/posts/my-favorite-article">2 Comments</span>
```

If a post is not using DisqusId, the tag appears as follows

```html
<span class="disqus-comment-count" data-disqus-identifier="" data-disqus-url="http://yoursite.com/posts/my-favorite-article">4 Comments</span>
```