### PR TITLE
Logo margin

### DIFF
--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -37,6 +37,10 @@ line-height-title = 1.3em
 logo-url = hexo-config("customize.logo.url")
 logo-width = 0px + hexo-config("customize.logo.width")
 logo-height = 0px + hexo-config("customize.logo.height")
+logo-margin-top = 0px + (hexo-config("customize.logo.margin.top") || 0)
+logo-margin-right = 0px + (hexo-config("customize.logo.margin.right") || 0)
+logo-margin-bottom = 0px + (hexo-config("customize.logo.margin.bottom") || 0)
+logo-margin-left = 0px + (hexo-config("customize.logo.margin.left") || 0)
 
 // Sidebar
 sidebar = hexo-config("customize.sidebar")

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -61,10 +61,7 @@ code
     background-position: 0px 10px
     background-repeat: no-repeat
     background-size: logo-width logo-height
-    margin-top: logo-margin-top
-    margin-right: logo-margin-right
-    margin-bottom: logo-margin-bottom
-    margin-left: logo-margin-left
+    margin: logo-margin-top logo-margin-right logo-margin-bottom logo-margin-left
 
 .main-body
     margin-top: - nav-height

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -61,6 +61,10 @@ code
     background-position: 0px 10px
     background-repeat: no-repeat
     background-size: logo-width logo-height
+    margin-top: logo-margin-top
+    margin-right: logo-margin-right
+    margin-bottom: logo-margin-bottom
+    margin-left: logo-margin-left
 
 .main-body
     margin-top: - nav-height


### PR DESCRIPTION
Added support for margin spacing on the logo image. A new customize variable was added, named `margin`, with options `top`, `right`, `bottom`, `left`, specified in pixels. The default is 0px margin. Example usage:

**_config.yml**

``` yaml
customize:
  logo:
    url: /images/primaryobjects.png
    width: 248
    height: 33
    margin:
      top: 5
      right: 6
      bottom: 3
      left: 6
```

``` yaml
customize:
  logo:
    url: /images/primaryobjects.png
    width: 248
    height: 33
    margin:
      top: 5
```
