### PR TITLE
Add a very partial support of isso

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -45,6 +45,7 @@ comment:
     duoshuo: # enter duoshuo shortname here
     youyan: # enter youyan uid here
     facebook: # enter true to enable
+    isso: # enter the domain name of your own comment isso server eg. comments.example.com
 
 # Share
 share: default # options: jiathis, bdshare, addtoany, default

--- a/layout/comment/counter.ejs
+++ b/layout/comment/counter.ejs
@@ -5,6 +5,8 @@
         <span class="disqus-comment-count" data-disqus-identifier="<%= post.disqusId || '' %>" data-disqus-url="<%= post.permalink %>">0</span>
     <% } else if (theme.comment.duoshuo) { %>
         <span class="ds-thread-count" data-thread-key="<%= post.path %>">0</span>
+    <% } else if (theme.comment.isso) { %>
+        <span><a href="/<%= post.path %>#isso-thread"></a></span>
     <% } %>
 </span>
 <% } %>

--- a/layout/comment/index.ejs
+++ b/layout/comment/index.ejs
@@ -8,6 +8,8 @@
         <%- partial('comment/youyan') %>
     <% } else if (theme.comment.facebook) { %>
       <%- partial('comment/facebook') %>
+    <% } else if (theme.comment.isso) { %>
+        <%- partial('comment/isso') %>
     <% } %>
     </section>
 <% } %>

--- a/layout/comment/isso.ejs
+++ b/layout/comment/isso.ejs
@@ -1,0 +1,8 @@
+<% if (typeof(script) !== 'undefined' && script) { %>
+    <script data-isso="//<%= theme.comment.isso %>"
+            src="//<%= theme.comment.isso %>/js/embed.min.js">
+    </script>
+<% } else { %>
+    <section id="isso-thread"></section>
+<% } %>
+

--- a/layout/comment/scripts.ejs
+++ b/layout/comment/scripts.ejs
@@ -6,4 +6,6 @@
     <%- partial('comment/youyan', { script: true }) %>
 <% } else if (theme.comment.facebook) { %>
     <%- partial('comment/facebook', { script: true }) %>
+<% } else if (theme.comment.isso) { %>
+    <%- partial('comment/isso', { script: true }) %>
 <% } %>


### PR DESCRIPTION
[Isso](https://posativ.org/isso/) is a commenting server similar to Disqus.

Requirements :

- Obviously (because it is the main goal) you must install your own isso server eg. comments.example.com
- You must match your [server configuration](https://posativ.org/isso/docs/configuration/server/) and your [client configuration](https://posativ.org/isso/docs/configuration/client/) by editing the `layout/comment/isso.ejs` file

Bug :

- The counter is not displayed but the number of comments is displayed below the thumbnail (with `layout/comment/counter.ejs`). If someone would develop it like `layout/comment/disqus.ejs`, [this](https://posativ.org/isso/docs/extras/api/#id7) can help.
