### PR TITLE
Widget for sticky posts.

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -16,6 +16,7 @@ sidebar:
     newer: 'newer'
     older: 'older'
     recents: 'recents'
+    sticky: 'Popular'
     archives: 'archives'
     categories: 'categories'
     links: 'links'

--- a/layout/widget/sticky_posts.ejs
+++ b/layout/widget/sticky_posts.ejs
@@ -1,0 +1,25 @@
+<% if (site.posts.length) { %>
+    <div class="widget-wrap">
+        <h3 class="widget-title"><%= __('sidebar.sticky') %></h3>
+        <div class="widget">
+            <ul id="recent-post" class="<%= (theme.customize.thumbnail?'':'no-thumbnail') %>">
+                <% site.posts.filter(function(post) { return post.sticky; }).sort('date', -1).limit(5).each(function(post) { %>
+                    <% if (!post.hidden) { %>
+                        <li>
+                            <% if (theme.customize.thumbnail === true) { %>
+                            <div class="item-thumbnail">
+                                <%- partial('common/thumbnail.ejs', {post: post}) %>
+                            </div>
+                            <% } %>
+                            <div class="item-inner">
+                                <p class="item-category"><%- list_categories(post.categories, {show_count: false, depth:2, class: 'article-category', style: 'none', separator: '<i class="icon fa fa-angle-right"></i>'}) %></p>
+                                <p class="item-title"><a href="<%- url_for((post.link?post.link:post.path)) %>" class="title"><%= post.title %></a></p>
+                                <p class="item-date"><time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date) %></time></p>
+                            </div>
+                        </li>
+                    <% } %>
+                <% }) %>
+            </ul>
+        </div>
+    </div>
+<% } %>

--- a/layout/widget/sticky_posts.ejs
+++ b/layout/widget/sticky_posts.ejs
@@ -3,7 +3,7 @@
         <h3 class="widget-title"><%= __('sidebar.sticky') %></h3>
         <div class="widget">
             <ul id="recent-post" class="<%= (theme.customize.thumbnail?'':'no-thumbnail') %>">
-                <% site.posts.filter(function(post) { return post.sticky; }).sort('date', -1).limit(5).each(function(post) { %>
+                <% site.posts.filter(function(post) { return post.sticky; }).sort('sticky', -1).limit(5).each(function(post) { %>
                     <% if (!post.hidden) { %>
                         <li>
                             <% if (theme.customize.thumbnail === true) { %>


### PR DESCRIPTION
Hi! I've created a widget for displaying sticky posts in the sidebar. To use this, edit the theme's `_config.yml` to include the `sticky_posts` widget:

```
widgets:
  - sticky_posts
```

Next, in any `/source/_posts/post.md` file, add the following variable:

```
sticky: 1
```

The value for sticky determines in what order the posts will display in the sidebar. Higher values show first, allowing you to control the sort order of sticky posts. :)