### PR TITLE
添加畅言社会化评论框插件

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -46,6 +46,10 @@ comment:
     youyan: # enter youyan uid here
     facebook: # enter true to enable
     isso: # enter the domain name of your own comment isso server eg. comments.example.com
+    changyan:
+        appId: # enter the changyan appId here
+        appKey: # enter the changyan appKey here
+        on: # enter true to enable
 
 # Share
 share: default # options: jiathis, bdshare, addtoany, default

--- a/layout/comment/changyan.ejs
+++ b/layout/comment/changyan.ejs
@@ -1,0 +1,45 @@
+<% if (typeof(script) !== 'undefined' && script && is_post()) { %>
+    <div id="SOHUCS" sid="<%= page.permalink %>"></div>
+    <script type="text/javascript">
+        (function() {
+            var appid = '<%= theme.comment.changyan.appId %>';
+            var conf = '<%= theme.comment.changyan.appKey %>';
+            var width = window.innerWidth || document.documentElement.clientWidth;
+            if (width < 960) {
+                window.document.write('<script id="changyan_mobile_js" charset="utf-8" type="text/javascript" src="https://changyan.sohu.com/upload/mobile/wap-js/changyan_mobile.js?client_id=' + appid + '&conf=' + conf + '"><\/script>');
+            } else {
+                var loadJs = function(d, a) {
+                    var c = document.getElementsByTagName("head")[0] || document.head || document.documentElement;
+                    var b = document.createElement("script");
+                    b.setAttribute("type", "text/javascript");
+                    b.setAttribute("charset", "UTF-8");
+                    b.setAttribute("src", d);
+                    if (typeof a === "function") {
+                        if (window.attachEvent) {
+                            b.onreadystatechange = function() {
+                                var e = b.readyState;
+                                if (e === "loaded" || e === "complete") {
+                                    b.onreadystatechange = null;
+                                    a()
+                                }
+                            }
+                        } else {
+                            b.onload = a
+                        }
+                    }
+                    c.appendChild(b)
+                };
+                loadJs("https://changyan.sohu.com/upload/changyan.js", function() {
+                    window.changyan.api.config({
+                        appid: appid,
+                        conf: conf
+                    })
+                });
+            }
+        })();
+    </script>
+<% } else { %>
+    <div id="SOHUCS">
+        <noscript>Please enable JavaScript to view the <a href="//changyan.kuaizhan.com/">comments powered by Changyan.</a></noscript>
+    </div>
+<% } %>

--- a/layout/comment/index.ejs
+++ b/layout/comment/index.ejs
@@ -10,6 +10,8 @@
       <%- partial('comment/facebook') %>
     <% } else if (theme.comment.isso) { %>
         <%- partial('comment/isso') %>
+    <% } else if (theme.comment.changyan.on) { %>
+        <%- partial('comment/changyan') %>
     <% } %>
     </section>
 <% } %>

--- a/layout/comment/scripts.ejs
+++ b/layout/comment/scripts.ejs
@@ -8,4 +8,6 @@
     <%- partial('comment/facebook', { script: true }) %>
 <% } else if (theme.comment.isso) { %>
     <%- partial('comment/isso', { script: true }) %>
+<% } else if (theme.comment.changyan.on) { %>
+    <%- partial('comment/changyan', { script: true }) %>
 <% } %>


### PR DESCRIPTION
在本插件的基础上添加了畅言的社会化评论插件，关于changyan.ejs中的`is_post()`函数判断问题，如果不写的话首页就会同样出现评论框。本插件已经经过实践证实可用，具体见我的博客（[http://qinjiangbo.com](http://qinjiangbo.com)）。希望能接入进去，谢谢！