### PR TITLE
cdn.mathjax.org has been retired

### DIFF
--- a/layout/plugin/scripts.ejs
+++ b/layout/plugin/scripts.ejs
@@ -30,6 +30,6 @@
         <script type="text/x-mathjax-config">
             MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] } });
         </script>
-        <%- js('https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML') %>
+        <%- js('https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML') %>
     <% } %>
 <% } %>


### PR DESCRIPTION
The MathJax CDN was shut down on April 30, 2017. Based on https://www.mathjax.org/cdn-shutting-down/, they recommend [cdnjs](https://cdnjs.com/) from CloudFlare as alternative CDN provider