### PR TITLE
Update Valine & Add avatar support

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -58,6 +58,9 @@ comment:
         notify: # enter true to enable <Mail notifier> https://github.com/xCss/Valine/wiki/Valine-%E8%AF%84%E8%AE%BA%E7%B3%BB%E7%BB%9F%E4%B8%AD%E7%9A%84%E9%82%AE%E4%BB%B6%E6%8F%90%E9%86%92%E8%AE%BE%E7%BD%AE
         verify: # enter true to enable <Validation code>
         placeholder: Just Do It # enter the comment box placeholder
+        avatar: identicon # (''/mm/identicon/monsterid/wavatar/retro/hide), more to see https://valine.js.org/avatar/
+        avatar_cdn: https://gravatar.loli.net/avatar/ # avatar CDN address, default gravatar.loli.net
+        pageSize: 10 # comments of one page
 
 # Share
 share: default # options: jiathis, bdshare, addtoany, default

--- a/layout/comment/valine.ejs
+++ b/layout/comment/valine.ejs
@@ -1,6 +1,7 @@
 <% if (typeof(script) !== 'undefined' && script) { %>
     <script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
-    <script src="//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7-rc3/dist/Valine.min.js"></script>
+    <script src='//unpkg.com/valine/dist/Valine.min.js'></script>
+   <!-- <script src="//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7-rc3/dist/Valine.min.js"></script> -->
     <script>
         new Valine({
             el: '#valine-thread' ,
@@ -8,7 +9,10 @@
             verify:<%= theme.comment.valine.verify %>,
             app_id: '<%= theme.comment.valine.appId %>',
             app_key: '<%= theme.comment.valine.appKey %>',
-            placeholder: '<%= theme.comment.valine.placeholder %>'
+            placeholder: '<%= theme.comment.valine.placeholder %>',
+            pageSize: '<%= theme.comment.valine.pageSize %>',
+            avatar: '<%= theme.comment.valine.avatar %>',
+            avatar_cdn:  '<%= theme.comment.valine.avatar_cdn %>'
         });
     </script>
 <% } else { %>

--- a/layout/comment/valine.ejs
+++ b/layout/comment/valine.ejs
@@ -1,7 +1,6 @@
 <% if (typeof(script) !== 'undefined' && script) { %>
     <script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
     <script src='//unpkg.com/valine/dist/Valine.min.js'></script>
-   <!-- <script src="//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7-rc3/dist/Valine.min.js"></script> -->
     <script>
         new Valine({
             el: '#valine-thread' ,


### PR DESCRIPTION
Update Valine to the latest version (for now v1.1.9-beta9).
Add 'comments avatar' and 'pageSize' features.
Default comment avatar CDN: https://gravatar.loli.net/avatar/ .