### PR TITLE
Added rel=noopener to social links to resolve lighthouse best practice

### DIFF
--- a/layout/common/sidebar.ejs
+++ b/layout/common/sidebar.ejs
@@ -6,7 +6,7 @@
             <% for (var i in theme.customize.social_links) { %>
                 <% if (theme.customize.social_links[i]) { %>
                 <li>
-                    <a class="social-tooltip" title="<%= i %>" href="<%- url_for(theme.customize.social_links[i]) %>" target="_blank">
+                    <a class="social-tooltip" title="<%= i %>" href="<%- url_for(theme.customize.social_links[i]) %>" target="_blank" rel="noopener">
                         <i class="icon fa fa-<%= i %>"></i>
                     </a>
                 </li>


### PR DESCRIPTION
This PR resolves some one of the issues when running Google Lighthouse.

https://developers.google.com/web/tools/lighthouse/audits/noopener