### PR TITLE
Added hexo-pwa capabilities to the theme

### DIFF
--- a/layout/common/head.ejs
+++ b/layout/common/head.ejs
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
+
+    <%- partial('pwa/index') %>
     <%
         var title = page.title;
         if (is_archive()) {

--- a/layout/pwa/index.ejs
+++ b/layout/pwa/index.ejs
@@ -1,0 +1,20 @@
+<% if (config.pwa) { %>
+<%
+  var icon = config.pwa.manifest.body.icons.find(icon => icon.sizes === '152x152');
+%>
+<% if (icon) { %>
+<link rel="icon" href="/<%= icon.src %>" />
+<link rel="apple-touch-icon" href="/<%= icon.src %>" />
+
+<meta name="msapplication-TileImage" content="/<%= icon.src %>" />
+<% } %>
+
+<meta name="msapplication-TileColor" content="<%= theme.customize.theme_color %>" />
+
+<meta name="theme-color" content="<%= theme.customize.theme_color %>" />
+
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="default" />
+<meta name="apple-mobile-web-app-title" content="<%= config.pwa.manifest.body.name %>" />
+
+<% } %>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "hexo-theme-hueman",
   "version": "0.2.1",
-  "private": true
+  "private": true,
+  "peerDependencies": {
+    "hexo-pwa": ">= 0.1.3",
+  }
 }


### PR DESCRIPTION
This change adds PWA capabilities to the theme when using the hexo-pwa plugin.

Extract from my _config.yaml
```yaml
pwa:
  manifest:
    path: /manifest.json
    body:
      name: Marco Franssen blog
      short_name: Marco F blog
      start_url: .
      description: Blog by Marco Franssen, covering software development!
      theme_color: "#006bde"
      background_color: "#ffffff"
      display: standalone
      icons:
        - src: images/icons/icon-72x72.png
          sizes: 72x72
          type: image/png
        - src: images/icons/icon-96x96.png
          sizes: 96x96
          type: image/png
        - src: images/icons/icon-128x128.png
          sizes: 128x128
          type: image/png
        - src: images/icons/icon-144x144.png
          sizes: 144x144
          type: image/png
        - src: images/icons/icon-152x152.png
          sizes: 152x152
          type: image/png
        - src: images/icons/icon-192x192.png
          sizes: 192x192
          type: image/png
        - src: images/icons/icon-384x384.png
          sizes: 384x384
          type: image/png
        - src: images/icons/icon-512x512.png
          sizes: 512x512
          type: image/png
```