### PR TITLE
make container-inner-max-width configurable

### DIFF
--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -46,8 +46,10 @@ sidebar-toggle-width = 50px
 // Layout
 container-padding = 20px
 container-inner-min-width = 320px
-container-inner-max-width = 1120px
-article-padding = 20px
+if hexo-config("customize.max_width")
+    container-inner-max-width = convert(hexo-config("customize.max_width"))
+else
+    container-inner-max-width = 1120pxarticle-padding = 20px
 nav-height = 60px
 main-nav-child-width = 180px
 mobile-nav-width = 280px

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -49,7 +49,8 @@ container-inner-min-width = 320px
 if hexo-config("customize.max_width")
     container-inner-max-width = convert(hexo-config("customize.max_width"))
 else
-    container-inner-max-width = 1120pxarticle-padding = 20px
+    container-inner-max-width = 1120px
+article-padding = 20px
 nav-height = 60px
 main-nav-child-width = 180px
 mobile-nav-width = 280px


### PR DESCRIPTION
Allow max_width to be configurable.

```yaml
# Customize
customize:
    max_width: 1500px
```

Why? On large screen (eg Full HD, 4k) or with large ratio (18:9, 21:9) etc. the container feels very tiny and there is too much space on the borders.
So making the max width configurable allows the site to behave better on large screens.