### PR TITLE
updated date support

### DIFF
--- a/layout/common/post/date.ejs
+++ b/layout/common/post/date.ejs
@@ -6,11 +6,11 @@
     </a>
   </div>
 <% } %>
-<% if (post.update) { %>
+<% if (post.updated) { %>
 <div class="<%= class_name %>">
   <i class="fa fa-calendar-plus-o"></i>
   <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
-     <time datetime="<%= date_xml(post.update) %>" itemprop="dateModified"><%= date(post.update, date_format) %></time>
+     <time datetime="<%= date_xml(post.updated) %>" itemprop="dateModified"><%= date(post.updated, date_format) %></time>
   </a>
 </div>
 <% } %>

--- a/layout/common/post/date.ejs
+++ b/layout/common/post/date.ejs
@@ -1,8 +1,16 @@
 <% if (post.date) { %>
-    <div class="<%= class_name %>">
-      <i class="fa fa-calendar"></i>
-      <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
-         <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, date_format) %></time>
-      </a>
-    </div>
+  <div class="<%= class_name %>">
+    <i class="fa fa-calendar"></i>
+    <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
+       <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, date_format) %></time>
+    </a>
+  </div>
+<% } %>
+<% if (post.update) { %>
+<div class="<%= class_name %>">
+  <i class="fa fa-calendar-plus-o"></i>
+  <a href="<%- url_for(post.path) %>" class="<%= class_name %>">
+     <time datetime="<%= date_xml(post.update) %>" itemprop="dateModified"><%= date(post.update, date_format) %></time>
+  </a>
+</div>
 <% } %>


### PR DESCRIPTION
I added support for the updated date of a post.

See the updated field in [front-matter](https://hexo.io/docs/front-matter#Settings-amp-Their-Default-Values).

On my website it displays like this:

![image](https://user-images.githubusercontent.com/16578570/87231272-13b03280-c3b6-11ea-910d-e9a5a3159482.png)

I properly respected the `itemprop` and I used a calendar icon with a + sign that make think about an update.