### PR TITLE
Update facebook.ejs

### DIFF
--- a/layout/comment/facebook.ejs
+++ b/layout/comment/facebook.ejs
@@ -3,7 +3,7 @@
     var js, fjs = d.getElementsByTagName(s)[0];
     if (d.getElementById(id)) return;
     js = d.createElement(s); js.id = id;
-    js.src = "//connect.facebook.net/<%= config.language ? config.language.split('-').join('_') : 'en' %>/sdk.js#xfbml=1&version=v2.8";
+    js.src = "//connect.facebook.net/<%= config.language ? config.language.split('-').join('_') : 'en' %>/sdk.js#xfbml=1&version=v9.0";
     fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
 <% } else { %>


### PR DESCRIPTION
Facebook SDK version 2.8 couldn't work anymore. I followed facebook documentation and changed SDK version to v9.0. It's working.
The documentation is as following.
https://developers.facebook.com/docs/plugins/comments/