### PR TITLE
Update sidebar.styl - delete obsolete a

### DIFF
--- a/source/css/_partial/sidebar.styl
+++ b/source/css/_partial/sidebar.styl
@@ -209,7 +209,6 @@
                     background-image: url(thumbnail-default-small)
                     background-size: 100% 100%
         .item-inner
-            a
             .item-category
                 font-size: 13px
                 text-transform: uppercase


### PR DESCRIPTION
There is an obsolete "a" behind 「.item_inner」. Without removing this, users cannot change 「.item-title font-size」. Because 「.item-category font-size」 comes first. And 「recent-post」 works fine without it. Pleaser review this change. Thanks.