### PR TITLE
Update google-analytics to use gtag.js

### DIFF
--- a/layout/plugin/google-analytics.ejs
+++ b/layout/plugin/google-analytics.ejs
@@ -1,10 +1,10 @@
-<script type="text/javascript">
-(function(i,s,o,g,r,a,m) {i['GoogleAnalyticsObject']=r;i[r]=i[r]||function() {
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.plugins.google_analytics %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', '<%= theme.plugins.google_analytics %>', 'auto');
-ga('send', 'pageview');
-
+  gtag('config', '<%= theme.plugins.google_analytics %>');
 </script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
This has been the preferred way for using Google Analytics for several years now.

The code is similar to what is in the [default landscape theme](https://github.com/hexojs/hexo-theme-landscape/pull/110) and what is
described on [Google's documentation page](https://developers.google.com/analytics/devguides/collection/gtagjs/
).